### PR TITLE
Fix shared-state bugs and cut allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 To use the `oxygen` package, install it using:
 
 ```sh
-  go get github.com/gromey/oxygen@latest
+go get github.com/gromey/oxygen@latest
 ```
 
 ## Getting Started
@@ -20,7 +20,7 @@ To use the `oxygen` package, install it using:
 After you get the library, you must generate your type using the following command:
 
 ```sh
-  go run github.com/gromey/oxygen/cmd/generate -n=name
+go run github.com/gromey/oxygen/cmd/generate -n=name
 ```
 
 In this command, you must specify a name of your new formatter. The name must contain only letters and be as simple as possible.

--- a/common.go
+++ b/common.go
@@ -6,6 +6,30 @@ import (
 	"reflect"
 )
 
+type buffer struct {
+	b []byte
+}
+
+func (b *buffer) Write(p []byte) (int, error) {
+	b.b = append(b.b, p...)
+	return len(p), nil
+}
+
+func (b *buffer) WriteByte(c byte) error {
+	b.b = append(b.b, c)
+	return nil
+}
+
+func (b *buffer) WriteString(s string) (int, error) {
+	b.b = append(b.b, s...)
+	return len(s), nil
+}
+
+func (b *buffer) Bytes() []byte  { return b.b }
+func (b *buffer) Len() int       { return len(b.b) }
+func (b *buffer) Reset()         { b.b = b.b[:0] }
+func (b *buffer) String() string { return string(b.b) }
+
 var (
 	errExist = errors.New("exist")
 

--- a/decode.go
+++ b/decode.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"sync"
+	"unsafe"
 )
 
 // Proper usage of a sync.Pool requires each entry to have approximately
@@ -27,7 +27,7 @@ func (e *engine[T]) Unmarshal(data []byte, v any) error {
 	}
 
 	s := e.newDecodeState()
-	defer putDecodeState(s)
+	defer e.putDecodeState(s)
 
 	s.data = append(s.data, data...)
 
@@ -38,30 +38,30 @@ func (e *engine[T]) Unmarshal(data []byte, v any) error {
 type decodeState[T any] struct {
 	*engine[T]
 	context[T]
-	*bytes.Buffer
-	data []byte // copy of input
+	buffer
+	fieldBuf field[T]
+	data     []byte // copy of input
 }
 
-var decodeStatePool sync.Pool
-
 func (e *engine[T]) newDecodeState() *decodeState[T] {
-	if p := decodeStatePool.Get(); p != nil {
+	if p := e.decStatePool.Get(); p != nil {
 		s := p.(*decodeState[T])
-		s.field = new(field[T])
+		s.fieldBuf = field[T]{}
+		s.field = &s.fieldBuf
 		s.err = nil
 		s.Reset()
 		s.data = s.data[:0]
 		return s
 	}
 
-	s := &decodeState[T]{engine: e, Buffer: new(bytes.Buffer), data: make([]byte, 0, 512)}
-	s.field = new(field[T])
+	s := &decodeState[T]{engine: e, data: make([]byte, 0, 512)}
+	s.field = &s.fieldBuf
 	return s
 }
 
-func putDecodeState[T any](s *decodeState[T]) {
+func (e *engine[T]) putDecodeState(s *decodeState[T]) {
 	if cap(s.data) <= maxSize {
-		decodeStatePool.Put(s)
+		e.decStatePool.Put(s)
 	}
 }
 
@@ -172,6 +172,12 @@ func unmarshalerDecoder[T any](s *decodeState[T], v reflect.Value) error {
 	return nil
 }
 
+// buffString converts bytes to string without allocation.
+// Safe only for transient use — the returned string must not be stored.
+func buffString(bs []byte) string {
+	return unsafe.String(unsafe.SliceData(bs), len(bs)) //nolint:gosec
+}
+
 func boolDecoder[T any](s *decodeState[T], v reflect.Value) error {
 	if err := s.Decode(s.field.name, s.field.tag, s.data, s); err != nil {
 		return err
@@ -179,7 +185,7 @@ func boolDecoder[T any](s *decodeState[T], v reflect.Value) error {
 	if s.Len() == 0 {
 		return nil
 	}
-	r, err := strconv.ParseBool(s.String())
+	r, err := strconv.ParseBool(buffString(s.Bytes()))
 	v.SetBool(r)
 	return err
 }
@@ -191,7 +197,7 @@ func intDecoder[T any](s *decodeState[T], v reflect.Value) error {
 	if s.Len() == 0 {
 		return nil
 	}
-	r, err := strconv.ParseInt(s.String(), 10, bitSize(v.Kind()))
+	r, err := strconv.ParseInt(buffString(s.Bytes()), 10, bitSize(v.Kind()))
 	v.SetInt(r)
 	return err
 }
@@ -203,7 +209,7 @@ func uintDecoder[T any](s *decodeState[T], v reflect.Value) error {
 	if s.Len() == 0 {
 		return nil
 	}
-	r, err := strconv.ParseUint(s.String(), 10, bitSize(v.Kind()))
+	r, err := strconv.ParseUint(buffString(s.Bytes()), 10, bitSize(v.Kind()))
 	v.SetUint(r)
 	return err
 }
@@ -215,7 +221,7 @@ func floatDecoder[T any](s *decodeState[T], v reflect.Value) error {
 	if s.Len() == 0 {
 		return nil
 	}
-	r, err := strconv.ParseFloat(s.String(), bitSize(v.Kind()))
+	r, err := strconv.ParseFloat(buffString(s.Bytes()), bitSize(v.Kind()))
 	v.SetFloat(r)
 	return err
 }
@@ -257,7 +263,9 @@ func bytesDecoder[T any](s *decodeState[T], v reflect.Value) error {
 	if s.Len() == 0 {
 		return nil
 	}
-	v.SetBytes(s.Bytes())
+	bs := make([]byte, s.Len())
+	copy(bs, s.Bytes())
+	v.SetBytes(bs)
 	return nil
 }
 

--- a/encode.go
+++ b/encode.go
@@ -1,12 +1,10 @@
 package oxygen
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
-	"sync"
 )
 
 const marshalError = "encode data from"
@@ -15,35 +13,38 @@ const marshalError = "encode data from"
 // If v is nil, Marshal returns an encoder error.
 func (e *engine[T]) Marshal(v any) ([]byte, error) {
 	s := e.newEncodeState()
-	defer encodeStatePool.Put(s)
+	defer e.encStatePool.Put(s)
 
 	if s.marshal(v); s.err != nil {
 		return nil, s.err
 	}
 
-	return append([]byte(nil), s.Bytes()...), nil
+	buf := s.Bytes()
+	out := make([]byte, len(buf))
+	copy(out, buf)
+	return out, nil
 }
 
 type encodeState[T any] struct {
 	*engine[T]
 	context[T]
-	*bytes.Buffer // accumulated output
-	scratch       [64]byte
+	buffer
+	fieldBuf field[T]
+	scratch  [64]byte
 }
 
-var encodeStatePool sync.Pool
-
 func (e *engine[T]) newEncodeState() *encodeState[T] {
-	if p := encodeStatePool.Get(); p != nil {
+	if p := e.encStatePool.Get(); p != nil {
 		s := p.(*encodeState[T])
-		s.field = new(field[T])
+		s.fieldBuf = field[T]{}
+		s.field = &s.fieldBuf
 		s.err = nil
 		s.Reset()
 		return s
 	}
 
-	s := &encodeState[T]{engine: e, Buffer: new(bytes.Buffer)}
-	s.field = new(field[T])
+	s := &encodeState[T]{engine: e}
+	s.field = &s.fieldBuf
 	return s
 }
 
@@ -122,11 +123,10 @@ func (f *structFields[T]) encode(s *encodeState[T], v reflect.Value, wrap bool) 
 }
 
 func marshallerEncoder[T any](s *encodeState[T], v reflect.Value) error {
-	tmp := reflect.ValueOf(v.Interface())
-	v = reflect.New(v.Type())
-	v.Elem().Set(tmp)
+	pv := reflect.New(v.Type())
+	pv.Elem().Set(v)
 
-	f, ok := s.IsMarshaller(v)
+	f, ok := s.IsMarshaller(pv)
 	if !ok {
 		return nil
 	}
@@ -136,23 +136,23 @@ func marshallerEncoder[T any](s *encodeState[T], v reflect.Value) error {
 		return err
 	}
 
-	return s.Encode(s.field.name, s.field.tag, p, s.Buffer)
+	return s.Encode(s.field.name, s.field.tag, p, &s.buffer)
 }
 
 func boolEncoder[T any](s *encodeState[T], v reflect.Value) error {
-	return s.Encode(s.field.name, s.field.tag, strconv.AppendBool(s.scratch[:0], v.Bool()), s.Buffer)
+	return s.Encode(s.field.name, s.field.tag, strconv.AppendBool(s.scratch[:0], v.Bool()), &s.buffer)
 }
 
 func intEncoder[T any](s *encodeState[T], v reflect.Value) error {
-	return s.Encode(s.field.name, s.field.tag, strconv.AppendInt(s.scratch[:0], v.Int(), 10), s.Buffer)
+	return s.Encode(s.field.name, s.field.tag, strconv.AppendInt(s.scratch[:0], v.Int(), 10), &s.buffer)
 }
 
 func uintEncoder[T any](s *encodeState[T], v reflect.Value) error {
-	return s.Encode(s.field.name, s.field.tag, strconv.AppendUint(s.scratch[:0], v.Uint(), 10), s.Buffer)
+	return s.Encode(s.field.name, s.field.tag, strconv.AppendUint(s.scratch[:0], v.Uint(), 10), &s.buffer)
 }
 
 func floatEncoder[T any](s *encodeState[T], v reflect.Value) error {
-	return s.Encode(s.field.name, s.field.tag, strconv.AppendFloat(s.scratch[:0], v.Float(), 'g', -1, bitSize(v.Kind())), s.Buffer)
+	return s.Encode(s.field.name, s.field.tag, strconv.AppendFloat(s.scratch[:0], v.Float(), 'g', -1, bitSize(v.Kind())), &s.buffer)
 }
 
 //func arrayEncoder[T any](s *encodeState[T], v reflect.Value) error {
@@ -175,7 +175,7 @@ func pointerEncoder[T any](s *encodeState[T], v reflect.Value) error {
 }
 
 func bytesEncoder[T any](s *encodeState[T], v reflect.Value) error {
-	return s.Encode(s.field.name, s.field.tag, v.Bytes(), s.Buffer)
+	return s.Encode(s.field.name, s.field.tag, v.Bytes(), &s.buffer)
 }
 
 //func sliceEncoder[T any](s *encodeState[T], v reflect.Value) error {
@@ -183,12 +183,12 @@ func bytesEncoder[T any](s *encodeState[T], v reflect.Value) error {
 //}
 
 func stringEncoder[T any](s *encodeState[T], v reflect.Value) error {
-	return s.Encode(s.field.name, s.field.tag, append(s.scratch[:0], v.String()...), s.Buffer)
+	return s.Encode(s.field.name, s.field.tag, append(s.scratch[:0], v.String()...), &s.buffer)
 }
 
 func structEncoder[T any](s *encodeState[T], v reflect.Value) error {
 	f := s.cachedFields(v.Type())
-	return f.encode(s, reflect.ValueOf(v.Interface()), s.wrap)
+	return f.encode(s, v, s.wrap)
 }
 
 func unsupportedTypeEncoder[T any](s *encodeState[T], _ reflect.Value) error {

--- a/engine.go
+++ b/engine.go
@@ -88,6 +88,10 @@ type engine[T any] struct {
 	wrap, removeWrapper, separate, removeSeparator bool
 	structOpener, structCloser, valueSeparator     []byte
 	marshaller, unmarshaler                        reflect.Type
+	encStatePool                                   sync.Pool
+	decStatePool                                   sync.Pool
+	coderCache                                     sync.Map // map[reflect.Type]*coders[T]
+	fieldCache                                     sync.Map // map[reflect.Type]structFields[T]
 }
 
 type coders[T any] struct {
@@ -95,15 +99,12 @@ type coders[T any] struct {
 	decoderFunc[T]
 }
 
-var coderCache sync.Map // map[reflect.Type]*coders[T]
-
 // cachedCoders is like typeCoders but uses a cache to avoid repeated work.
 func (e *engine[T]) cachedCoders(t reflect.Type) *coders[T] {
-	if c, ok := coderCache.Load(t); ok {
+	if c, ok := e.coderCache.Load(t); ok {
 		return c.(*coders[T])
 	}
-
-	c, _ := coderCache.LoadOrStore(t, e.typeCoders(t))
+	c, _ := e.coderCache.LoadOrStore(t, e.typeCoders(t))
 	return c.(*coders[T])
 }
 
@@ -180,14 +181,12 @@ type field[T any] struct {
 
 type structFields[T any] []*field[T]
 
-var fieldCache sync.Map // map[reflect.Type]structFields[T]
-
 // cachedFields is like typeFields but uses a cache to avoid repeated work.
 func (e *engine[T]) cachedFields(t reflect.Type) structFields[T] {
-	if c, ok := fieldCache.Load(t); ok {
+	if c, ok := e.fieldCache.Load(t); ok {
 		return c.(structFields[T])
 	}
-	c, _ := fieldCache.LoadOrStore(t, e.typeFields(t))
+	c, _ := e.fieldCache.LoadOrStore(t, e.typeFields(t))
 	return c.(structFields[T])
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gromey/oxygen
 
-go 1.18
+go 1.20


### PR DESCRIPTION
- Move pools/caches into engine[T] to fix multi-engine coexistence
- Inline fieldBuf and buffer to eliminate per-call heap allocs
- Fix bytesDecoder: copy before Reset to prevent silent corruption
- Fix reflect boxing in struct/marshaller encoders
- Zero-copy buffString via unsafe.String; bump go.mod to 1.20